### PR TITLE
browserdetect.org did not recognize Win10

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'HTTP::BrowserDetect', '== 2.01';
+requires 'HTTP::BrowserDetect', '== 2.05';
 requires 'Mojolicious::Lite';
 requires 'Data::Printer';
 requires 'Plack';


### PR DESCRIPTION
After upgrading my Windows-laptop I wanted to check the new Edge
browser on http://browserdetect.org only to find out it did not
recognize it; luckily the new CPAN version DOES recognize it!
